### PR TITLE
fix the url in the plugin metadata

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,7 +4,7 @@
 # about: Authorship Plugin for Discourse
 # version: 0.1.0
 # author: Angus McLeod
-# url: https://github.com/paviliondev/discourse-authorship
+# url: https://github.com/angusmcleod/discourse-authorship
 
 register_asset 'stylesheets/common/common.scss'
 


### PR DESCRIPTION
Right now it's https://github.com/paviliondev/discourse-authorship, which gives 404.